### PR TITLE
fix: removed localStorage from useEffect dependency array

### DIFF
--- a/src/pages/Authentication/Otp/Otp.tsx
+++ b/src/pages/Authentication/Otp/Otp.tsx
@@ -45,7 +45,7 @@ export default function Otp(): JSX.Element {
       // @ts-ignore
       setPin(localStoragePin);
     } 
-  }, [localStorage]);
+  }, []);
 
   
   return (


### PR DESCRIPTION
The localStorage object was misplaced in the dependency array and had to be removed, so as to avoid unforeseen errors.