### PR TITLE
fix: splash screen navigation issue in desktop

### DIFF
--- a/src/pages/OnboardingSlides/OnboardingSlides.tsx
+++ b/src/pages/OnboardingSlides/OnboardingSlides.tsx
@@ -20,11 +20,7 @@ const OnboardingSlides = ({ slides }: OnboardingSlidesProps) => {
   const navigate = useNavigate();
   const handleNextSlide = () => {
     if (currentIndex === slides.length - 1) {
-      if (mobBtn) {
         navigate("/sign-up");
-      } else {
-        return;
-      }
     } else {
       setCurrentIndex(currentIndex + 1);
     }


### PR DESCRIPTION
Initially, first visit user were not able to navigate to the sign-in/sign-up page when they view the last onboarding slide on desktop.